### PR TITLE
only send US country if state is present STOR-3702

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -798,7 +798,7 @@ module ActiveMerchant #:nodoc:
             doc["v1"].city billing_address[:city] if billing_address[:city]
             doc["v1"].state billing_address[:state] if billing_address[:state]
             doc["v1"].zipCode billing_address[:zip] if billing_address[:zip]
-            doc["v1"].ctry "US"
+            doc["v1"].ctry "US" if billing_address[:state].present?
           end
 
           doc["v1"].email options[:email] if options[:email]


### PR DESCRIPTION
Jira [STOR-3702](https://sparefoot.atlassian.net/browse/STOR-3702)

[FMS PR-15457](https://github.com/rednovalabs/fms/pull/15457)

#### Issue
TSYS will process payments w/out a state or country code

####
FMS will only set state if country is US & state is valid, if there is no state code, don't send over 'US' country code.

#### Testing
- a US address w/out a valid state code should not send state or country code
- a NON US address should not sent state or country code ever
- a US address w/a valid state code should send over country 'US' code