### PR TITLE
STOR-17291 Handle empty responses to accommodate new REXML validation rules

### DIFF
--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -473,21 +473,17 @@ module ActiveMerchant #:nodoc:
       def parse(xml)
         doc = Nokogiri::XML(xml).remove_namespaces!
 
-        # normalize the response body so we don't have to know the name of the
-        # root element
-        body = begin
-          doc.at_xpath('/Envelope/Body').children.first.children.to_xml
+        # normalize the response body so we don't have to know the name of the root element
+        children = begin
+          doc.at_xpath('/Envelope/Body').children.first.children
         rescue NoMethodError
-          # if their API has an error it responds with HTML :rolleyes:
-          doc.to_xml
+          # if their API has an error it responds with HTML or an empty body :rolleyes:
+          doc.root&.children
         end
-        new_response_body = <<-XML
-        <root>
-        #{body}
-        </root>
-        XML
+        doc.root = doc.create_element('root')
+        doc.root.children = children if children.present?
 
-        Hash.from_xml(new_response_body)['root']
+        Hash.from_xml(doc.to_xml)['root'] || {}
       end
 
       def success_from(response)


### PR DESCRIPTION
TSYS sometimes sends back empty response bodies for 500 errors. After upgrading to `rexml >= 3.3.2`, a new validation was added to ensure that the `<?xml  ?>` tag is the first tag in the XML document to mitigate a DoS CVE. 
ref: https://github.com/ruby/rexml/pull/162/files

In turn, that caused issues with our parsing in here since we would wrap the entire document (including the `<?xml ?>` tag) in a `<root>` tag. By using nokogiri to insert the `root` tag and calling `.to_xml` on the whole thing, we are able to ensure that the top-most tag is the `<?xml ?>` tag.

<details>
  <summary>Some fun examples</summary>

  ```rb
  def parse_old(xml)
    doc = Nokogiri::XML(xml).remove_namespaces!

    # normalize the response body so we don't have to know the name of the
    # root element
    body = begin
      doc.at_xpath('/Envelope/Body').children.first.children.to_xml
    rescue NoMethodError
      # if their API has an error it responds with HTML :rolleyes:
      doc.to_xml
    end
    new_response_body = <<-XML
    <root>
    #{body}
    </root>
    XML

    Hash.from_xml(new_response_body)['root']
  end


  def parse(xml)
    doc = Nokogiri::XML(xml).remove_namespaces!

    # normalize the response body so we don't have to know the name of the root element
    children = begin
      doc.at_xpath('/Envelope/Body').children.first.children
    rescue NoMethodError
      # if their API has an error it responds with HTML or an empty body :rolleyes:
      doc.root&.children
    end
    doc.root = doc.create_element('root')
    doc.root.children = children if children.present?

    Hash.from_xml(doc.to_xml)['root'] || {}
  end

  # ======== Empty Body Edge Case ========
  xml = ""
  parse(xml)
  # => {}

  parse_old(xml)
  # => REXML::ParseException: Malformed XML: XML declaration is not at the start
  #    Line: 2
  #    Position: 32
  #    Last 80 unconsumed characters:
  #
  #    from /Users/josh.westbrook/.asdf_i386/installs/ruby/3.2.5/lib/ruby/gems/3.2.0/gems/rexml-3.3.9/lib/rexml/parsers/baseparser.rb:746:in `process_instruction'


  # ======== Happy Path ========
  xml = "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><ns2:UpdtRecurrProfResponse xmlns=\"http://postilion/realtime/portal/soa/xsd/Faults/2009/01\" xmlns:ns2=\"http://postilion/realtime/merchantframework/xsd/v1/\"><ns2:custId>1739914276192120242</ns2:custId><ns2:rspCode>00</ns2:rspCode></ns2:UpdtRecurrProfResponse></S:Body></S:Envelope>"
  parse(xml)
  # => {"custId"=>"1739914276192120242", "rspCode"=>"00"}

  parse_old(xml)
  # => {"custId"=>"1739914276192120242", "rspCode"=>"00"}
  ```
</details>